### PR TITLE
Change pie chart to map chart and change sizing of map

### DIFF
--- a/src/components/Maps/PatientsDistributionByProvince.js
+++ b/src/components/Maps/PatientsDistributionByProvince.js
@@ -1,20 +1,20 @@
 import React, { useReducer, useEffect, useRef } from 'react';
-import Highcharts from 'highcharts';
+import Highcharts, { geojson } from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import HighchartsMap from 'highcharts/modules/map';
 import mapDataCanada from '@highcharts/map-collection/countries/ca/ca-all.geo.json';
 import PropTypes from 'prop-types';
 
-import LoadingIndicator, { trackPromise, usePromiseTracker } from '../LoadingIndicator/LoadingIndicator';
+import LoadingIndicator, { usePromiseTracker } from '../LoadingIndicator/LoadingIndicator';
 import { notify, NotificationAlert } from '../../utils/alert';
-import { getCounts } from '../../api/api';
+
 
 // Initialize HighchartsMap
 HighchartsMap(Highcharts);
 
 const initialState = {
   title: {
-    text: 'Treating Centre Province',
+    text: 'Distribution by Province of Residence',
   },
   credits: {
     enabled: false,
@@ -98,12 +98,12 @@ function reducer(state, action) {
   }
 }
 
-function TreatingCentreProvince({ datasetId }) {
+function PatientsDistributionByProvince({ provinceOfResidenceObj }) {
   const { promiseInProgress } = usePromiseTracker();
   const [chartOptions, dispatchChartOptions] = useReducer(reducer, initialState);
   const notifyEl = useRef(null);
 
-  function processJson(data) {
+  function processData(data){
     const dataCount = [];
     Object.keys(data).forEach((name) => {
       if (provShortCodes.includes(name)) {
@@ -120,40 +120,22 @@ function TreatingCentreProvince({ datasetId }) {
     });
 
     return dataCount;
+
   }
 
   useEffect(() => {
-    // Mimic the didUpdate function
-    try {
-      if (datasetId) {
-        trackPromise(
-          getCounts(datasetId, 'enrollments', 'treatingCentreProvince')
-            .then((data) => {
-              let dataCount;
-
-              if (data) {
-                if (!data.results.enrollments[0]) {
-                  throw new Error();
-                }
-                const { treatingCentreProvince } = data.results.enrollments[0];
-
-                dataCount = processJson(treatingCentreProvince);
-              }
-              dispatchChartOptions({ type: 'addSeries', payload: dataCount });
-            }).catch(() => {
-              notify(
-                notifyEl,
-                'Some resources you requested were not available.',
-                'warning',
-              );
-              dispatchChartOptions({ type: 'addSeries', payload: [] });
-            }),
-        );
-      }
-    } catch (err) {
-      // console.log(err);
+    try{
+      let dataCount = processData(provinceOfResidenceObj);
+      dispatchChartOptions({ type: 'addSeries', payload: dataCount });
+    }catch{
+      notify(
+        notifyEl,
+        'Some resources you requested were not available.',
+        'warning',
+      );
+      dispatchChartOptions({ type: 'addSeries', payload: [] });
     }
-  }, [datasetId]);
+  }, [provinceOfResidenceObj]);
 
   return (
     <>
@@ -173,8 +155,8 @@ function TreatingCentreProvince({ datasetId }) {
   );
 }
 
-TreatingCentreProvince.propTypes = {
-  datasetId: PropTypes.string.isRequired,
+PatientsDistributionByProvince.propTypes = {
+  provinceOfResidenceObj: PropTypes.object.isRequired,
 };
 
-export default TreatingCentreProvince;
+export default PatientsDistributionByProvince;

--- a/src/components/Maps/PatientsDistributionByProvince.js
+++ b/src/components/Maps/PatientsDistributionByProvince.js
@@ -7,7 +7,9 @@ import PropTypes from 'prop-types';
 
 import LoadingIndicator, { usePromiseTracker } from '../LoadingIndicator/LoadingIndicator';
 import { notify, NotificationAlert } from '../../utils/alert';
-import {hcProvCodes, provShortCodes, provFullNames, highchartsMapInitialState} from '../../constants/constants';
+import {
+  hcProvCodes, provShortCodes, provFullNames, highchartsMapInitialState,
+} from '../../constants/constants';
 
 // Initialize HighchartsMap
 HighchartsMap(Highcharts);
@@ -50,7 +52,7 @@ function PatientsDistributionByProvince({ provinceOfResidenceObj }) {
   const [chartOptions, dispatchChartOptions] = useReducer(reducer, highchartsMapInitialState);
   const notifyEl = useRef(null);
 
-  function processData(data){
+  function processData(data) {
     const dataCount = [];
     Object.keys(data).forEach((name) => {
       if (provShortCodes.includes(name)) {
@@ -67,14 +69,13 @@ function PatientsDistributionByProvince({ provinceOfResidenceObj }) {
     });
 
     return dataCount;
-
   }
 
   useEffect(() => {
-    try{
-      let dataCount = processData(provinceOfResidenceObj);
+    try {
+      const dataCount = processData(provinceOfResidenceObj);
       dispatchChartOptions({ type: 'addSeries', payload: dataCount });
-    }catch{
+    } catch {
       notify(
         notifyEl,
         'Some resources you requested were not available.',
@@ -103,7 +104,7 @@ function PatientsDistributionByProvince({ provinceOfResidenceObj }) {
 }
 
 PatientsDistributionByProvince.propTypes = {
-  provinceOfResidenceObj: PropTypes.object.isRequired,
+  provinceOfResidenceObj: PropTypes.string.isRequired,
 };
 
 export default PatientsDistributionByProvince;

--- a/src/components/Maps/PatientsDistributionByProvince.js
+++ b/src/components/Maps/PatientsDistributionByProvince.js
@@ -1,5 +1,5 @@
 import React, { useReducer, useEffect, useRef } from 'react';
-import Highcharts, { geojson } from 'highcharts';
+import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import HighchartsMap from 'highcharts/modules/map';
 import mapDataCanada from '@highcharts/map-collection/countries/ca/ca-all.geo.json';

--- a/src/components/Maps/PatientsDistributionByProvince.js
+++ b/src/components/Maps/PatientsDistributionByProvince.js
@@ -7,66 +7,10 @@ import PropTypes from 'prop-types';
 
 import LoadingIndicator, { usePromiseTracker } from '../LoadingIndicator/LoadingIndicator';
 import { notify, NotificationAlert } from '../../utils/alert';
-
+import {hcProvCodes, provShortCodes, provFullNames, highchartsMapInitialState} from '../../constants/constants';
 
 // Initialize HighchartsMap
 HighchartsMap(Highcharts);
-
-const initialState = {
-  title: {
-    text: 'Distribution by Province of Residence',
-  },
-  credits: {
-    enabled: false,
-  },
-  legend: {
-    layout: 'vertical',
-    align: 'right',
-    verticalAlign: 'middle',
-  },
-  colorAxis: {
-    min: 0,
-    minColor: '#E6E7E8',
-    maxColor: '#005645',
-  },
-  chart: {
-    reflow: true,
-  },
-  yAxis:{
-    min: -10000,
-  },
-  xAxis:{
-    max: 10000,
-    min: -1000,
-  },
-  series: [
-    {
-      type: 'map',
-      name: 'Province',
-      mapData: mapDataCanada,
-      states: {
-        hover: {
-          color: '#BADA55',
-        },
-      },
-      dataLabels: {
-        enabled: false,
-        format: '{point.name}',
-      },
-    },
-  ],
-};
-
-// Highcharts Map requires a specific set of codes for provinces
-// and territories, as represented by hcProvCodes below.
-const hcProvCodes = [
-  'ca-ab', 'ca-bc', 'ca-mb', 'ca-nb', 'ca-nl', 'ca-nt', 'ca-ns',
-  'ca-nu', 'ca-on', 'ca-pe', 'ca-qc', 'ca-sk', 'ca-yt'];
-const provShortCodes = ['AB', 'BC', 'MB', 'NB', 'NL', 'NT', 'NS', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'];
-const provFullNames = [
-  'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick', 'Newfoundland and Labrador',
-  'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island',
-  'Quebec', 'Saskatchewan', 'Yukon Territory'];
 
 function reducer(state, action) {
   switch (action.type) {
@@ -74,6 +18,9 @@ function reducer(state, action) {
       return {
         ...state,
         ...{
+          title: {
+            text: 'Distribution by Province of Residence',
+          },
           series: [
             {
               data: action.payload,
@@ -100,7 +47,7 @@ function reducer(state, action) {
 
 function PatientsDistributionByProvince({ provinceOfResidenceObj }) {
   const { promiseInProgress } = usePromiseTracker();
-  const [chartOptions, dispatchChartOptions] = useReducer(reducer, initialState);
+  const [chartOptions, dispatchChartOptions] = useReducer(reducer, highchartsMapInitialState);
   const notifyEl = useRef(null);
 
   function processData(data){

--- a/src/components/Maps/TreatingCentreProvince.js
+++ b/src/components/Maps/TreatingCentreProvince.js
@@ -8,7 +8,9 @@ import PropTypes from 'prop-types';
 import LoadingIndicator, { trackPromise, usePromiseTracker } from '../LoadingIndicator/LoadingIndicator';
 import { notify, NotificationAlert } from '../../utils/alert';
 import { getCounts } from '../../api/api';
-import {hcProvCodes, provShortCodes, provFullNames, highchartsMapInitialState} from '../../constants/constants';
+import {
+  hcProvCodes, provShortCodes, provFullNames, highchartsMapInitialState,
+} from '../../constants/constants';
 
 // Initialize HighchartsMap
 HighchartsMap(Highcharts);

--- a/src/components/Maps/TreatingCentreProvince.js
+++ b/src/components/Maps/TreatingCentreProvince.js
@@ -8,65 +8,10 @@ import PropTypes from 'prop-types';
 import LoadingIndicator, { trackPromise, usePromiseTracker } from '../LoadingIndicator/LoadingIndicator';
 import { notify, NotificationAlert } from '../../utils/alert';
 import { getCounts } from '../../api/api';
+import {hcProvCodes, provShortCodes, provFullNames, highchartsMapInitialState} from '../../constants/constants';
 
 // Initialize HighchartsMap
 HighchartsMap(Highcharts);
-
-const initialState = {
-  title: {
-    text: 'Treating Centre Province',
-  },
-  credits: {
-    enabled: false,
-  },
-  legend: {
-    layout: 'vertical',
-    align: 'right',
-    verticalAlign: 'middle',
-  },
-  colorAxis: {
-    min: 0,
-    minColor: '#E6E7E8',
-    maxColor: '#005645',
-  },
-  chart: {
-    reflow: true,
-  },
-  yAxis:{
-    min: -10000,
-  },
-  xAxis:{
-    max: 10000,
-    min: -1000,
-  },
-  series: [
-    {
-      type: 'map',
-      name: 'Province',
-      mapData: mapDataCanada,
-      states: {
-        hover: {
-          color: '#BADA55',
-        },
-      },
-      dataLabels: {
-        enabled: false,
-        format: '{point.name}',
-      },
-    },
-  ],
-};
-
-// Highcharts Map requires a specific set of codes for provinces
-// and territories, as represented by hcProvCodes below.
-const hcProvCodes = [
-  'ca-ab', 'ca-bc', 'ca-mb', 'ca-nb', 'ca-nl', 'ca-nt', 'ca-ns',
-  'ca-nu', 'ca-on', 'ca-pe', 'ca-qc', 'ca-sk', 'ca-yt'];
-const provShortCodes = ['AB', 'BC', 'MB', 'NB', 'NL', 'NT', 'NS', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'];
-const provFullNames = [
-  'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick', 'Newfoundland and Labrador',
-  'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island',
-  'Quebec', 'Saskatchewan', 'Yukon Territory'];
 
 function reducer(state, action) {
   switch (action.type) {
@@ -74,6 +19,9 @@ function reducer(state, action) {
       return {
         ...state,
         ...{
+          title: {
+            text: 'Treating Centre Province',
+          },
           series: [
             {
               data: action.payload,
@@ -100,7 +48,7 @@ function reducer(state, action) {
 
 function TreatingCentreProvince({ datasetId }) {
   const { promiseInProgress } = usePromiseTracker();
-  const [chartOptions, dispatchChartOptions] = useReducer(reducer, initialState);
+  const [chartOptions, dispatchChartOptions] = useReducer(reducer, highchartsMapInitialState);
   const notifyEl = useRef(null);
 
   function processJson(data) {

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -37,34 +37,34 @@ export const provFullNames = [
   'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island',
   'Quebec', 'Saskatchewan', 'Yukon Territory'];
 
-  // Intial Highcharts state 
- export const highchartsMapInitialState = {
-    title: {
-      text: '',
-    },
-    credits: {
-      enabled: false,
-    },
-    legend: {
-      layout: 'vertical',
-      align: 'right',
-      verticalAlign: 'middle',
-    },
-    colorAxis: {
-      min: 0,
-      minColor: '#E6E7E8',
-      maxColor: '#005645',
-    },
-    chart: {
-      reflow: true,
-    },
-    yAxis:{
-      min: -10000,
-    },
-    xAxis:{
-      max: 10000,
-      min: -1000,
-    },
-  };
+// Intial Highcharts state
+export const highchartsMapInitialState = {
+  title: {
+    text: '',
+  },
+  credits: {
+    enabled: false,
+  },
+  legend: {
+    layout: 'vertical',
+    align: 'right',
+    verticalAlign: 'middle',
+  },
+  colorAxis: {
+    min: 0,
+    minColor: '#E6E7E8',
+    maxColor: '#005645',
+  },
+  chart: {
+    reflow: true,
+  },
+  yAxis: {
+    min: -10000,
+  },
+  xAxis: {
+    max: 10000,
+    min: -1000,
+  },
+};
 
 export default BASE_URL;

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -25,4 +25,46 @@ export const CLIN_METADATA = [
   'tumourboards',
 ];
 
+// Highcharts Map requires a specific set of codes for provinces
+// and territories, as represented by hcProvCodes below.
+export const hcProvCodes = [
+  'ca-ab', 'ca-bc', 'ca-mb', 'ca-nb', 'ca-nl', 'ca-nt', 'ca-ns',
+  'ca-nu', 'ca-on', 'ca-pe', 'ca-qc', 'ca-sk', 'ca-yt'];
+
+export const provShortCodes = ['AB', 'BC', 'MB', 'NB', 'NL', 'NT', 'NS', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'];
+export const provFullNames = [
+  'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick', 'Newfoundland and Labrador',
+  'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island',
+  'Quebec', 'Saskatchewan', 'Yukon Territory'];
+
+  // Intial Highcharts state 
+ export const highchartsMapInitialState = {
+    title: {
+      text: '',
+    },
+    credits: {
+      enabled: false,
+    },
+    legend: {
+      layout: 'vertical',
+      align: 'right',
+      verticalAlign: 'middle',
+    },
+    colorAxis: {
+      min: 0,
+      minColor: '#E6E7E8',
+      maxColor: '#005645',
+    },
+    chart: {
+      reflow: true,
+    },
+    yAxis:{
+      min: -10000,
+    },
+    xAxis:{
+      max: 10000,
+      min: -1000,
+    },
+  };
+
 export default BASE_URL;

--- a/src/views/PatientsOverview.js
+++ b/src/views/PatientsOverview.js
@@ -206,7 +206,7 @@ function PatientsOverview({ datasetName, datasetId }) {
                 {promiseInProgress === true ? (
                   <LoadingIndicator />
                 ) : (
-                  <PatientsDistributionByProvinceMapChart provinceOfResidenceObj={provinceOfResidenceObj} />
+                  <PatientsDistributionByProvinceMapChart provinceOfResidenceObj={JSON.stringify(provinceOfResidenceObj)} />
                 )}
               </CardBody>
             </Card>

--- a/src/views/PatientsOverview.js
+++ b/src/views/PatientsOverview.js
@@ -14,7 +14,7 @@ import { groupBy } from '../utils/utils';
 import { notify, NotificationAlert } from '../utils/alert';
 import CustomOfflineChart from '../components/Graphs/CustomOfflineChart';
 import { fetchPatients } from '../api/api';
-
+import PatientsDistributionByProvinceMapChart from '../components/Maps/PatientsDistributionByProvince'
 /*
  * Patient Overview view component
  * @param {string} datasetName
@@ -206,13 +206,7 @@ function PatientsOverview({ datasetName, datasetId }) {
                 {promiseInProgress === true ? (
                   <LoadingIndicator />
                 ) : (
-                  <CustomOfflineChart
-                    datasetName={datasetName}
-                    dataObject={provinceOfResidenceObj}
-                    chartType="pie"
-                    barTitle="Province Of Residence"
-                    height="400px; auto"
-                  />
+                  <PatientsDistributionByProvinceMapChart provinceOfResidenceObj={provinceOfResidenceObj} />
                 )}
               </CardBody>
             </Card>

--- a/src/views/PatientsOverview.js
+++ b/src/views/PatientsOverview.js
@@ -14,7 +14,7 @@ import { groupBy } from '../utils/utils';
 import { notify, NotificationAlert } from '../utils/alert';
 import CustomOfflineChart from '../components/Graphs/CustomOfflineChart';
 import { fetchPatients } from '../api/api';
-import PatientsDistributionByProvinceMapChart from '../components/Maps/PatientsDistributionByProvince'
+import PatientsDistributionByProvinceMapChart from '../components/Maps/PatientsDistributionByProvince';
 /*
  * Patient Overview view component
  * @param {string} datasetName


### PR DESCRIPTION
## Description

Patient overview displayed the 'Distribution by Province of Residence' information in a pie chart changed to a map chart to match the overviews page for 'Treating Centre Province'. Also, changed the map chart's sizing since it's relatively small.

## Before
![image](https://user-images.githubusercontent.com/37649170/120241490-bf08e680-c217-11eb-9283-ae98a40f64b5.png)
![image](https://user-images.githubusercontent.com/37649170/120241657-15762500-c218-11eb-9aea-7d9b34bb088b.png)


## Final
![image](https://user-images.githubusercontent.com/37649170/120241682-23c44100-c218-11eb-8368-8ba2c27c86c9.png)

