### PR TITLE
Persistent DatasetsDropdown with Redux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "candigv2_dashboard",
+  "name": "candig-server-beta-dashboard",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1770,6 +1770,15 @@
       "integrity": "sha512-O2joRmShgUcGBSyjp0pYFIP0Kv3y6jl8UXokEkcTI4D8FinTYsSt8OaHGQ/tI7WUF2eZTXKVJg6jQuEQS4d30w==",
       "optional": true
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -1830,8 +1839,7 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "optional": true
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1842,10 +1850,20 @@
       "version": "16.9.35",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
       "integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
-      "optional": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.16",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.16.tgz",
+      "integrity": "sha512-f/FKzIrZwZk7YEO9E1yoxIuDNRiDducxkFlkw/GNMGEnK9n4K8wJzlJBghpSuOVDgEUHoDkDF7Gi9lHNQR4siw==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/stack-utils": {
@@ -4711,8 +4729,7 @@
     "csstype": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
-      "optional": true
+      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -7772,6 +7789,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -8017,25 +8042,27 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/igv/-/igv-2.8.1.tgz",
       "integrity": "sha512-2TIwSYS9vZz2+fNeBucwqQzSP7WRGagMNdboojEVFkJNjEt2jnFa3XoyhkGrsDPmaESC6XEB16wXCdc4MzF6FQ==",
+      "requires": {
+        "igv-ui": "git+https://github.com/igvteam/igv-ui.git#ecb455c48cf46e8d36bfa3c868c2d1df59fa0d11",
+        "igv-utils": "git+https://github.com/igvteam/igv-utils.git#1db2aaf8b456daab321cb4a2663480c8d02c1139"
+      }
+    },
+    "igv-ui": {
+      "version": "git+https://github.com/igvteam/igv-ui.git#ecb455c48cf46e8d36bfa3c868c2d1df59fa0d11",
+      "from": "git+https://github.com/igvteam/igv-ui.git#v1.1.5",
+      "requires": {
+        "igv-utils": "github:igvteam/igv-utils#b01d4e5c6f1448e4b3abb955c813c1163c7b0bda"
+      },
       "dependencies": {
-        "igv-ui": {
-          "version": "git+https://github.com/igvteam/igv-ui.git#ecb455c48cf46e8d36bfa3c868c2d1df59fa0d11",
-          "from": "git+https://github.com/igvteam/igv-ui.git#ecb455c48cf46e8d36bfa3c868c2d1df59fa0d11",
-          "requires": {
-            "igv-utils": "github:igvteam/igv-utils#b01d4e5c6f1448e4b3abb955c813c1163c7b0bda"
-          },
-          "dependencies": {
-            "igv-utils": {
-              "version": "github:igvteam/igv-utils#b01d4e5c6f1448e4b3abb955c813c1163c7b0bda",
-              "from": "github:igvteam/igv-utils#v1.2.3"
-            }
-          }
-        },
         "igv-utils": {
-          "version": "git+https://github.com/igvteam/igv-utils.git#1db2aaf8b456daab321cb4a2663480c8d02c1139",
-          "from": "git+https://github.com/igvteam/igv-utils.git#1db2aaf8b456daab321cb4a2663480c8d02c1139"
+          "version": "github:igvteam/igv-utils#b01d4e5c6f1448e4b3abb955c813c1163c7b0bda",
+          "from": "github:igvteam/igv-utils#v1.2.3"
         }
       }
+    },
+    "igv-utils": {
+      "version": "git+https://github.com/igvteam/igv-utils.git#1db2aaf8b456daab321cb4a2663480c8d02c1139",
+      "from": "git+https://github.com/igvteam/igv-utils.git#v1.2.6"
     },
     "immer": {
       "version": "1.10.0",
@@ -13339,25 +13366,24 @@
       "integrity": "sha512-1LQSGAnFF4o++iPFgeBrMpS+ZHQg8ZGl9Zuf70v+OoLxuOnUeLCP7ugma+InBCUZzPnSLyWTLt/jyW+FAy5ELQ=="
     },
     "react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
+      "integrity": "sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
+        "@babel/runtime": "^7.12.1",
+        "@types/react-redux": "^7.1.16",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
       },
       "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+        "@babel/runtime": {
+          "version": "7.14.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
           "requires": {
-            "react-is": "^16.7.0"
+            "regenerator-runtime": "^0.13.4"
           }
         }
       }
@@ -15638,6 +15664,22 @@
         "url-parse": "^1.4.7",
         "xml-but-prettier": "^1.0.1",
         "zenscroll": "^4.0.2"
+      },
+      "dependencies": {
+        "react-redux": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
+          "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "hoist-non-react-statics": "^3.3.0",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.1.0",
+            "prop-types": "^15.6.1",
+            "react-is": "^16.6.0",
+            "react-lifecycles-compat": "^3.0.0"
+          }
+        }
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-loader-spinner": "^3.1.14",
     "react-notification-alert": "0.0.12",
     "react-promise-tracker": "^2.1.0",
+    "react-redux": "^7.2.4",
     "react-router-dom": "5.2.0",
     "react-scripts": "^3.4.3",
     "react-table": "^7.3.2",

--- a/src/components/Dropdowns/DatasetsDropdown.js
+++ b/src/components/Dropdowns/DatasetsDropdown.js
@@ -6,6 +6,7 @@ import {
   DropdownMenu,
   DropdownItem,
 } from 'reactstrap';
+import { useSelector, useDispatch } from 'react-redux';
 import { fetchDatasets } from '../../api/api';
 
 /*
@@ -13,10 +14,12 @@ import { fetchDatasets } from '../../api/api';
  * @param{func} A method that updates the state on the parent
  */
 function DatasetsDropdown({ updateState }) {
-  const [selectedDataset, setSelectedDataset] = useState('');
-  const [datasets, setDatasets] = useState({});
-  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const events = useSelector((state) => state);
+  const dispatch = useDispatch();
 
+  const [selectedDataset, setSelectedDataset] = useState(events.setData.selectedDataset);
+  const [datasets, setDatasets] = useState(events.setData.datasets);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
   const toggle = () => setDropdownOpen((prevState) => !prevState);
 
   /*
@@ -25,10 +28,8 @@ function DatasetsDropdown({ updateState }) {
    * @param {string} datasetId
    */
   function updateParentState(datasetName, datasetId) {
-    updateState({
-      datasetName,
-      datasetId,
-    });
+    dispatch({ type: 'SET_UPDATE_STATE', payload: { datasetName, datasetId } });
+    updateState(events.setData.update);
   }
 
   /*
@@ -39,6 +40,7 @@ function DatasetsDropdown({ updateState }) {
     const firstDataset = datasetsList[Object.keys(datasetsList)[0]];
     setSelectedDataset(firstDataset.name);
     updateParentState(firstDataset.name, firstDataset.id);
+    dispatch({ type: 'SET_SELECTED_DATASET', payload: firstDataset.name });
   }
 
   /*
@@ -64,6 +66,7 @@ function DatasetsDropdown({ updateState }) {
           const datasetsList = processDatasetJson(data.results.datasets);
           setDatasets(datasetsList);
           setFirstDataset(datasetsList);
+          dispatch({ type: 'SET_DATASETS', payload: datasetsList });
         });
     }
   });
@@ -74,6 +77,7 @@ function DatasetsDropdown({ updateState }) {
   function handleClick(e) {
     setSelectedDataset(e.currentTarget.textContent);
     updateParentState(e.currentTarget.textContent, e.currentTarget.id);
+    dispatch({ type: 'SET_SELECTED_DATASET', payload: e.currentTarget.textContent });
   }
 
   // This loop builds the dropdown items list

--- a/src/components/Maps/PatientsDistributionByProvince.js
+++ b/src/components/Maps/PatientsDistributionByProvince.js
@@ -104,7 +104,7 @@ function PatientsDistributionByProvince({ provinceOfResidenceObj }) {
 }
 
 PatientsDistributionByProvince.propTypes = {
-  provinceOfResidenceObj: PropTypes.string.isRequired,
+  provinceOfResidenceObj: PropTypes.objectOf(PropTypes.number).isRequired,
 };
 
 export default PatientsDistributionByProvince;

--- a/src/index.js
+++ b/src/index.js
@@ -28,23 +28,42 @@ import "assets/demo/demo.css";
 import "perfect-scrollbar/css/perfect-scrollbar.css";
 import routes from "./routes";
 import AdminLayout from "layouts/Admin.js";
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { loadState, saveState } from "store/sessionStorage";
+import reducer from 'store/reducer';
+
+const persistentState = loadState();
+const store = createStore(reducer, persistentState);
+
+store.subscribe(()=>{
+  saveState(store.getState({
+    selectedDataset: store.getState.selectedDataset,
+    datasets: store.getState.datasets,
+    update: store.getState.update
+  }));
+ 
+})
+
 const hist = createBrowserHistory();
 ReactDOM.render(
-  <SideBar>
-  <Router history={hist}>
-  <Switch>
-    <Route exact path="/v2/dashboard" render={() => <Redirect to="/v2/dashboard/overview" />} />
-        {routes.map((prop, key) => {
-          return (
-            <Route
-              path={prop.layout + prop.path}
-              key={key}
-              render={(prop) => <AdminLayout {...prop} />}
-            />
-          );
-        })}
-    </Switch>
-  </Router>
-  </SideBar>,
+  <Provider store={store}>
+    <SideBar>
+      <Router history={hist}>
+        <Switch>
+          <Route exact path="/v2/dashboard" render={() => <Redirect to="/v2/dashboard/overview" />} />
+            {routes.map((prop, key) => {
+              return (
+                <Route
+                  path={prop.layout + prop.path}
+                  key={key}
+                  render={(prop) => <AdminLayout {...prop} />}
+                />
+              );
+            })}
+        </Switch>
+      </Router>
+    </SideBar>
+  </Provider>,
   document.getElementById("root")
 );

--- a/src/layouts/Admin.js
+++ b/src/layouts/Admin.js
@@ -28,8 +28,6 @@ import Sidebar from "components/Sidebar/Sidebar.js";
 
 import routes from "./../routes.js";
 
-import BASE_URL from "../constants/constants";
-
 let ps;
 
 class Dashboard extends React.Component {

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,0 +1,43 @@
+import { combineReducers } from 'redux';
+
+const DEFAULT = [{}];
+
+const setData = (state=DEFAULT, action)=>{
+    switch(action.type){
+        case "SET_SELECTED_DATASET":
+            return {
+                ...state,
+                selectedDataset: action.payload,  
+            }
+        case "SET_DATASETS":
+            return {
+                ...state,
+                datasets : {
+                    ...action.payload
+                }
+            }
+        case "SET_UPDATE_STATE": 
+            return {
+            ...state,
+                update : {
+                   ...action.payload
+                }
+        }
+        default:
+            return {
+                ...state,
+                selectedDataset: '',
+                datasets: {},  
+                update: {
+                    datasetName: '',
+                    datasetId: '',
+                }
+            }
+    }
+}
+
+const rootReducer = combineReducers({
+    setData
+});
+
+export default rootReducer;

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -1,8 +1,6 @@
 import { combineReducers } from 'redux';
 
-const DEFAULT = [{}];
-
-const setData = (state=DEFAULT, action)=>{
+const setData = (state, action)=>{
     switch(action.type){
         case "SET_SELECTED_DATASET":
             return {
@@ -28,6 +26,10 @@ const setData = (state=DEFAULT, action)=>{
                 ...state,
                 selectedDataset: '',
                 datasets: {},  
+                update: {
+                    datasetName: '',
+                    datasetId: '',
+                }
             }
     }
 }

--- a/src/store/reducer.js
+++ b/src/store/reducer.js
@@ -28,10 +28,6 @@ const setData = (state=DEFAULT, action)=>{
                 ...state,
                 selectedDataset: '',
                 datasets: {},  
-                update: {
-                    datasetName: '',
-                    datasetId: '',
-                }
             }
     }
 }

--- a/src/store/sessionStorage.js
+++ b/src/store/sessionStorage.js
@@ -1,0 +1,23 @@
+export const loadState = () => {
+    try {
+      const serializedState = sessionStorage.getItem('state');
+  
+      if (serializedState === null) {
+        return undefined;
+      }
+  
+      return JSON.parse(serializedState);
+    } catch (error) {
+      return undefined;
+    }
+  };
+  
+  export const saveState = (state) => {
+    try {
+      const serializedState = JSON.stringify(state);
+      sessionStorage.setItem('state', serializedState);
+    } catch (error) {
+      // Ignore write errors.
+      console.log(error);
+    }
+  };

--- a/src/views/CustomVisualization.js
+++ b/src/views/CustomVisualization.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 // reactstrap components
 import { Row, Col, Container } from 'reactstrap';
 
+import { useSelector } from 'react-redux';
 import CustomVisualizationDropDown from '../components/Dropdowns/CustomVisualizationDropDown';
 
 /*
@@ -10,7 +10,10 @@ import CustomVisualizationDropDown from '../components/Dropdowns/CustomVisualiza
  * @param {string} datasetId
  * @param {string} datasetName
  */
-function CustomVisualization({ datasetId, datasetName }) {
+function CustomVisualization() {
+  const events = useSelector((state) => state);
+  const { datasetName } = events.setData.update;
+  const { datasetId } = events.setData.update;
   return (
     <>
       <div className="content">
@@ -34,10 +37,5 @@ function CustomVisualization({ datasetId, datasetName }) {
     </>
   );
 }
-
-CustomVisualization.propTypes = {
-  datasetId: PropTypes.string.isRequired,
-  datasetName: PropTypes.string.isRequired,
-};
 
 export default CustomVisualization;

--- a/src/views/Overview.js
+++ b/src/views/Overview.js
@@ -5,8 +5,7 @@ import {
   Card, CardBody, CardTitle, Row, Col,
 } from 'reactstrap';
 
-// Consts
-import BASEURL from 'constants/constants';
+import {connect} from 'react-redux'
 
 import Server from './../components/Graphs/Server.js';
 import BarChart from './../components/Graphs/BarChart.js';
@@ -31,8 +30,8 @@ class Dashboard extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.datasetId) {
-      this.fetchData(this.props.datasetId);
+    if (this.props.events.setData.update.datasetId) {
+      this.fetchData(this.props.events.setData.update.datasetId);
     }
   }
 
@@ -197,7 +196,7 @@ class Dashboard extends React.Component {
             <Col lg="3" md="6" sm="6">
               <Card>
                 <CardBody>
-                  <Server datasetId={this.state.datasetId} />
+                  <Server datasetId={this.props.events.setData.update.datasetId} />
                 </CardBody>
               </Card>
             </Col>
@@ -205,7 +204,7 @@ class Dashboard extends React.Component {
               <Card>
                 <CardBody>
                   <BarChart
-                    datasetId={this.props.datasetId}
+                    datasetId={this.props.events.setData.update.datasetId}
                     table="patients"
                     field="gender"
                     title="Gender Distribution"
@@ -217,7 +216,7 @@ class Dashboard extends React.Component {
               <Card>
                 <CardBody>
                   <BarChart
-                    datasetId={this.props.datasetId}
+                    datasetId={this.props.events.setData.update.datasetId}
                     table="treatments"
                     field="therapeuticModality"
                     title="Treatment Modalities"
@@ -229,7 +228,7 @@ class Dashboard extends React.Component {
               <Card>
                 <CardBody>
                   <BarChart
-                    datasetId={this.props.datasetId}
+                    datasetId={this.props.events.setData.update.datasetId}
                     table="enrollments"
                     field="enrollmentInstitution"
                     title="Enrollment Institutions"
@@ -242,14 +241,14 @@ class Dashboard extends React.Component {
             <Col lg="6" md="6" sm="6">
               <Card>
                 <CardBody>
-                  <TreatingCentreProvince datasetId={this.props.datasetId} />
+                  <TreatingCentreProvince datasetId={this.props.events.setData.update.datasetId} />
                 </CardBody>
               </Card>
             </Col>
             <Col lg="6" md="6" sm="6">
               <Card>
                 <CardBody>
-                  <CancerType datasetId={this.props.datasetId} />
+                  <CancerType datasetId={this.props.events.setData.update.datasetId} />
                 </CardBody>
               </Card>
             </Col>
@@ -260,4 +259,10 @@ class Dashboard extends React.Component {
   }
 }
 
-export default Dashboard;
+const mapStateToProps = state => {
+  return {
+      events: state
+  }
+}
+
+export default connect(mapStateToProps)(Dashboard);

--- a/src/views/Overview.js
+++ b/src/views/Overview.js
@@ -1,112 +1,82 @@
 /* eslint-disable */
-import React from 'react';
+import React, {useState} from 'react';
 // reactstrap components
 import {
   Card, CardBody, CardTitle, Row, Col,
 } from 'reactstrap';
 
-import {connect} from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux';
 
 import Server from './../components/Graphs/Server.js';
 import BarChart from './../components/Graphs/BarChart.js';
 import CancerType from './../components/Graphs/CancerType.js';
 import TreatingCentreProvince from './../components/Maps/TreatingCentreProvince';
 
-import {getCounts} from '../api/api'
+import {getCounts} from '../api/api';
 
-const initialState = {
-  datasetName: '',
-  datasetId: '',
-  provinces: 0,
-  hospitals: 0,
-  patients: 0,
-  samples: 0,
-};
+/*
+ * Overview view component
+ */
 
-class Dashboard extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = initialState;
-  }
+function Dashboard(){
+  const events = useSelector((state) => state);
 
-  componentDidMount() {
-    if (this.props.events.setData.update.datasetId) {
-      this.fetchData(this.props.events.setData.update.datasetId);
-    }
-  }
+  const [datasetId, setDatasetId] = useState(events.setData.update.datasetId);
+  const [provinces, setProvinces] = useState(0);
+  const [hospitals, setHospitals] = useState(0);
+  const [patients, setPatients] = useState(0);
+  const [samples, setSamples] = useState(0);
 
-  fetchData(datasetId) {
-    if (datasetId) {
-      this.getCounters(datasetId, 'enrollments', [
-        'datasetId',
-        'treatingCentreName',
-        'treatingCentreProvince',
-      ]);
-      this.getCounters(datasetId, 'samples', ['datasetId']);
-    }
-  }
-
-  getCounters(datasetId, table, fields) {
-    getCounts(datasetId, table, fields)
-      .then((data) => {
-        if (table === 'enrollments') {
-          const datasetId = this.getDatadetIdFromEnrollments(data);
-          this.setState({
-            patients: data.results.enrollments[0].datasetId[datasetId],
-            hospitals: Object.keys(
-              data.results.enrollments[0].treatingCentreName,
-            ).length,
-            provinces: Object.keys(
-              data.results.enrollments[0].treatingCentreProvince,
-            ).length,
-            samples: this.state.samples,
-          });
-        } else if (table === 'samples') {
-          const datasetId = this.getDatadetIdFromSamples(data);
-          this.setState({
-            patients: this.state.patients,
-            hospitals: this.state.hospitals,
-            provinces: this.state.provinces,
-            samples: data.results.samples[0].datasetId[datasetId],
-          });
-        }
-      })
-      .catch((err) => {
-        this.setState({
-          datasetName: '',
-          datasetId: '',
-          provinces: 'Not Available',
-          hospitals: 'Not Available',
-          patients: 'Not Available',
-          samples: 'Not Available',
-        });
-      });
-  }
-
-  getDatadetIdFromEnrollments(data) {
+  
+  function getDatadetIdFromEnrollments(data){
     return Object.keys(data.results.enrollments[0].datasetId)[0];
   }
 
-  getDatadetIdFromSamples(data) {
+  function getDatadetIdFromSamples(data){
     return Object.keys(data.results.samples[0].datasetId)[0];
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.datasetId !== prevProps.datasetId) {
-      this.setState({
-        datasetId: this.props.datasetId,
-        datasetName: this.props.datasetId,
+  function getCounters(datasetId, table, fields){
+    getCounts(datasetId, table, fields)
+      .then((data) => {
+        if (table === 'enrollments') {
+          setDatasetId(getDatadetIdFromEnrollments(data));
+          setPatients(data.results.enrollments[0].datasetId[datasetId]);
+          setHospitals(Object.keys(
+            data.results.enrollments[0].treatingCentreName,
+          ).length);
+          setProvinces(Object.keys(
+            data.results.enrollments[0].treatingCentreProvince,
+          ).length);
+        } else if (table === 'samples') {
+          const datasetId = getDatadetIdFromSamples(data);
+          setSamples(data.results.samples[0].datasetId[datasetId]); 
+        }
+      })
+      .catch((err) => {
+        setDatasetId('');
+        setProvinces('Not Available');
+        setHospitals('Not Available');
+        setPatients('Not Available');
+        setSamples('Not Available');      
       });
-      this.getCounters(this.props.datasetId, 'enrollments', [
+  }
+
+  function fetchData(datasetId){
+    if (datasetId) {
+      getCounters(datasetId, 'enrollments', [
         'datasetId',
         'treatingCentreName',
         'treatingCentreProvince',
       ]);
-      this.getCounters(this.props.datasetId, 'samples', ['datasetId']);
+      getCounters(datasetId, 'samples', ['datasetId']);
     }
   }
-
-  render() {
+ 
+  if (events.setData.update.datasetId) {
+      fetchData(events.setData.update.datasetId);
+  }
+  
     return (
       <>
         <div className="content">
@@ -123,7 +93,7 @@ class Dashboard extends React.Component {
                     <Col md="8" xs="7">
                       <div className="numbers">
                         <p className="card-category">Provinces</p>
-                        <CardTitle tag="p">{this.state.provinces}</CardTitle>
+                        <CardTitle tag="p">{provinces}</CardTitle>
                         <p />
                       </div>
                     </Col>
@@ -143,7 +113,7 @@ class Dashboard extends React.Component {
                     <Col md="8" xs="7">
                       <div className="numbers">
                         <p className="card-category">Hospitals</p>
-                        <CardTitle tag="p">{this.state.hospitals}</CardTitle>
+                        <CardTitle tag="p">{hospitals}</CardTitle>
                         <p />
                       </div>
                     </Col>
@@ -163,7 +133,7 @@ class Dashboard extends React.Component {
                     <Col md="8" xs="7">
                       <div className="numbers">
                         <p className="card-category">Patients</p>
-                        <CardTitle tag="p">{this.state.patients}</CardTitle>
+                        <CardTitle tag="p">{patients}</CardTitle>
                         <p />
                       </div>
                     </Col>
@@ -183,7 +153,7 @@ class Dashboard extends React.Component {
                     <Col md="8" xs="7">
                       <div className="numbers">
                         <p className="card-category">Samples</p>
-                        <CardTitle tag="p">{this.state.samples}</CardTitle>
+                        <CardTitle tag="p">{samples}</CardTitle>
                         <p />
                       </div>
                     </Col>
@@ -196,7 +166,7 @@ class Dashboard extends React.Component {
             <Col lg="3" md="6" sm="6">
               <Card>
                 <CardBody>
-                  <Server datasetId={this.props.events.setData.update.datasetId} />
+                  <Server datasetId={datasetId} />
                 </CardBody>
               </Card>
             </Col>
@@ -204,7 +174,7 @@ class Dashboard extends React.Component {
               <Card>
                 <CardBody>
                   <BarChart
-                    datasetId={this.props.events.setData.update.datasetId}
+                    datasetId={datasetId}
                     table="patients"
                     field="gender"
                     title="Gender Distribution"
@@ -216,7 +186,7 @@ class Dashboard extends React.Component {
               <Card>
                 <CardBody>
                   <BarChart
-                    datasetId={this.props.events.setData.update.datasetId}
+                    datasetId={datasetId}
                     table="treatments"
                     field="therapeuticModality"
                     title="Treatment Modalities"
@@ -228,7 +198,7 @@ class Dashboard extends React.Component {
               <Card>
                 <CardBody>
                   <BarChart
-                    datasetId={this.props.events.setData.update.datasetId}
+                    datasetId={datasetId}
                     table="enrollments"
                     field="enrollmentInstitution"
                     title="Enrollment Institutions"
@@ -241,14 +211,14 @@ class Dashboard extends React.Component {
             <Col lg="6" md="6" sm="6">
               <Card>
                 <CardBody>
-                  <TreatingCentreProvince datasetId={this.props.events.setData.update.datasetId} />
+                  <TreatingCentreProvince datasetId={datasetId} />
                 </CardBody>
               </Card>
             </Col>
             <Col lg="6" md="6" sm="6">
               <Card>
                 <CardBody>
-                  <CancerType datasetId={this.props.events.setData.update.datasetId} />
+                  <CancerType datasetId={datasetId} />
                 </CardBody>
               </Card>
             </Col>
@@ -257,12 +227,5 @@ class Dashboard extends React.Component {
       </>
     );
   }
-}
 
-const mapStateToProps = state => {
-  return {
-      events: state
-  }
-}
-
-export default connect(mapStateToProps)(Dashboard);
+export default Dashboard;

--- a/src/views/PatientsOverview.js
+++ b/src/views/PatientsOverview.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
-import PropTypes from 'prop-types';
+
 // reactstrap components
 import {
   Card, CardBody, CardTitle, Row, Col,
 } from 'reactstrap';
 import useStateWithCallback from 'use-state-with-callback';
 
+import { useSelector } from 'react-redux';
 import LoadingIndicator, {
   trackPromise,
   usePromiseTracker,
@@ -15,12 +16,14 @@ import { notify, NotificationAlert } from '../utils/alert';
 import CustomOfflineChart from '../components/Graphs/CustomOfflineChart';
 import { fetchPatients } from '../api/api';
 import PatientsDistributionByProvinceMapChart from '../components/Maps/PatientsDistributionByProvince';
+
 /*
  * Patient Overview view component
  * @param {string} datasetName
  * @param {string} datasetId
  */
-function PatientsOverview({ datasetName, datasetId }) {
+function PatientsOverview() {
+  const events = useSelector((state) => state);
   const [patientsCount, setPatientsCount] = useState();
   const [provincesCount, setProvincesCount] = useState('');
   const [genderObj, setGenderObj] = useState({});
@@ -39,7 +42,8 @@ function PatientsOverview({ datasetName, datasetId }) {
     occupationalOrEnvironmentalExposureObj,
     setOccupationalOrEnvironmentalExposureObj,
   ] = useState({});
-
+  const { datasetName } = events.setData.update;
+  const { datasetId } = events.setData.update;
   const { promiseInProgress } = usePromiseTracker();
   const notifyEl = useRef(null);
 
@@ -233,10 +237,5 @@ function PatientsOverview({ datasetName, datasetId }) {
     </>
   );
 }
-
-PatientsOverview.propTypes = {
-  datasetName: PropTypes.string.isRequired,
-  datasetId: PropTypes.string.isRequired,
-};
 
 export default PatientsOverview;

--- a/src/views/PatientsOverview.js
+++ b/src/views/PatientsOverview.js
@@ -19,8 +19,6 @@ import PatientsDistributionByProvinceMapChart from '../components/Maps/PatientsD
 
 /*
  * Patient Overview view component
- * @param {string} datasetName
- * @param {string} datasetId
  */
 function PatientsOverview() {
   const events = useSelector((state) => state);
@@ -42,8 +40,7 @@ function PatientsOverview() {
     occupationalOrEnvironmentalExposureObj,
     setOccupationalOrEnvironmentalExposureObj,
   ] = useState({});
-  const { datasetName } = events.setData.update;
-  const { datasetId } = events.setData.update;
+  const { datasetName, datasetId } = events.setData.update;
   const { promiseInProgress } = usePromiseTracker();
   const notifyEl = useRef(null);
 
@@ -210,7 +207,7 @@ function PatientsOverview() {
                 {promiseInProgress === true ? (
                   <LoadingIndicator />
                 ) : (
-                  <PatientsDistributionByProvinceMapChart provinceOfResidenceObj={JSON.stringify(provinceOfResidenceObj)} />
+                  <PatientsDistributionByProvinceMapChart provinceOfResidenceObj={provinceOfResidenceObj} />
                 )}
               </CardBody>
             </Card>

--- a/src/views/VariantsSearch.js
+++ b/src/views/VariantsSearch.js
@@ -1,8 +1,9 @@
 import React, { useState, useRef } from 'react';
-import PropTypes from 'prop-types';
 import {
   Button, Form, FormGroup, Label, Input, Row, UncontrolledAlert,
 } from 'reactstrap';
+
+import { useSelector } from 'react-redux';
 
 import VariantsTable from '../components/Tables/VariantsTable';
 import { searchVariant } from '../api/api';
@@ -11,7 +12,9 @@ import { notify, NotificationAlert } from '../utils/alert';
 
 import '../assets/css/VariantsSearch.css';
 
-function VariantsSearch({ datasetId }) {
+function VariantsSearch() {
+  const events = useSelector((state) => state);
+  const { datasetId } = events.setData.update;
   const [rowData, setRowData] = useState([]);
   const [displayVariantsTable, setDisplayVariantsTable] = useState(false);
   const notifyEl = useRef(null);
@@ -82,9 +85,5 @@ function VariantsSearch({ datasetId }) {
     </>
   );
 }
-
-VariantsSearch.propTypes = {
-  datasetId: PropTypes.string.isRequired,
-};
 
 export default VariantsSearch;


### PR DESCRIPTION
## Description

Issue #17 

Previously the data would reset when switching between views. If you were on Mock2 data and then changed from overview to patient overview it would call the API for Mock1. The new behaviour was to have the datasetsDropdown persist the data to stop unnecessary API requests.

## Before
https://user-images.githubusercontent.com/37649170/121723592-8e3c7300-ca9b-11eb-9bfe-fada4342c9de.mp4

## After
https://user-images.githubusercontent.com/37649170/121723281-27b75500-ca9b-11eb-9e21-5f5d1d43f28f.mp4




