### PR TITLE
Change styling of dataset dropdown to raw form instead of conversion to capitalization

### DIFF
--- a/src/components/Dropdowns/DatasetsDropdown.js
+++ b/src/components/Dropdowns/DatasetsDropdown.js
@@ -103,7 +103,7 @@ function DatasetsDropdown({ updateState }) {
         paddingRight: '10px',
       }}
     >
-      <DropdownToggle caret nav style={{ color: 'white', fontSize: 12 }}>
+      <DropdownToggle caret nav style={{ color: 'white' }}>
         {selectedDataset}
       </DropdownToggle>
       <DropdownMenu right>{datasetList}</DropdownMenu>

--- a/src/components/Navbars/TopBar.js
+++ b/src/components/Navbars/TopBar.js
@@ -133,24 +133,18 @@ class Header extends React.Component {
                 className="navbar-toggler"
                 onClick={() => this.openSidebar()}
               >
-                <span className="navbar-toggler-bar bar1" />
-                <span className="navbar-toggler-bar bar2" />
-                <span className="navbar-toggler-bar bar3" />
+              
               </button>
             </div>
             <NavbarBrand href="/">{this.getBrand()}</NavbarBrand>
           </div>
-          <NavbarToggler onClick={this.toggle}>
-            <span className="navbar-toggler-bar navbar-kebab" />
-            <span className="navbar-toggler-bar navbar-kebab" />
-            <span className="navbar-toggler-bar navbar-kebab" />
-          </NavbarToggler>
+          <NavbarToggler onClick={this.toggle}/>
           <Collapse
             isOpen={this.state.isOpen}
             navbar
             className="justify-content-end"
           >
-            <Nav navbar>
+            <Nav>
               {this.props.datasetVisible === true ? 
                 (<DatasetsDropdown updateState={this.props.updateState} />) :
                 <></> }


### PR DESCRIPTION
Issue #28 

## Description

This PR addresses displaying the dataset name in the dropdown to be in its raw form and not converted into capitalization. 

## Before
![image](https://user-images.githubusercontent.com/37649170/122987454-7693a300-d355-11eb-8373-7c15ba979410.png)

## After
![image](https://user-images.githubusercontent.com/37649170/122986879-d5a4e800-d354-11eb-8beb-602c68724dde.png)
