### PR TITLE
Hotfix: Wording in table

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -77,7 +77,7 @@ export const ListOfReferenceNames = [
 ];
 
 export const BeaconFreqTableColumnDefs = [
-  { headerName: 'Reference Chromosome', field: 'referenceName' },
+  { headerName: 'Chromosome', field: 'referenceName' },
   {
     headerName: 'Position',
     field: 'start',
@@ -107,7 +107,7 @@ export const BeaconFreqTableColumnDefs = [
 ];
 
 export const BeaconRangeTableColumnDefs = [
-  { headerName: 'Reference Chromosome', field: 'referenceName' },
+  { headerName: 'Chromosome', field: 'referenceName' },
   {
     headerName: 'Position',
     field: 'start',


### PR DESCRIPTION
## Description
Changing the wording of the column header from 'Reference Chromosome' to 'Chromosome'.