### PR TITLE
Update chromosome dropdown to include both variations of chromosomes

### DIFF
--- a/src/components/IGV/BamInstance.js
+++ b/src/components/IGV/BamInstance.js
@@ -28,7 +28,12 @@ function BamInstance({
         // browser.on('trackclick', (track, popoverData) => {
         //    console.log(popoverData);
         // });
-        browser.search(`chr${chromosome}`);
+        if (chromosome.includes('chr')) {
+          browser.search(chromosome);
+        }
+        else {
+          browser.search(`chr${chromosome}`);
+        }
       });
     }
   }, [tracks, genome, chromosome, datasetId]);

--- a/src/components/IGV/BamInstance.js
+++ b/src/components/IGV/BamInstance.js
@@ -30,8 +30,7 @@ function BamInstance({
         // });
         if (chromosome.includes('chr')) {
           browser.search(chromosome);
-        }
-        else {
+        } else {
           browser.search(`chr${chromosome}`);
         }
       });

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -76,9 +76,14 @@ export const ListOfReferenceNames = [
   'chr17', 'chr18', 'chr19', 'chr20', 'chr21', 'chr22', 'chrX', 'chrY', 'chrMT',
 ];
 
-export const ListOfSimpleReferenceNames = [
+export const ListOfShortReferenceNames = [
   '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16',
   '17', '18', '19', '20', '21', '22', 'X', 'Y', 'MT',
+];
+
+export const ListOfLongReferenceNames = [
+  'chr1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6', 'chr7', 'chr8', 'chr9', 'chr10', 'chr11', 'chr12', 'chr13', 'chr14', 'chr15', 'chr16',
+  'chr17', 'chr18', 'chr19', 'chr20', 'chr21', 'chr22', 'chrX', 'chrY', 'chrMT',
 ];
 
 export const BeaconFreqTableColumnDefs = [

--- a/src/views/BamBrowser.js
+++ b/src/views/BamBrowser.js
@@ -5,7 +5,7 @@ import {
 
 import { useSelector } from 'react-redux';
 import { MultiSelect } from 'react-multi-select-component';
-import { BASE_URL, ListOfSimpleReferenceNames, referenceToIgvTrack } from '../constants/constants';
+import { BASE_URL, ListOfReferenceNames, referenceToIgvTrack } from '../constants/constants';
 
 import BamInstance from '../components/IGV/BamInstance';
 import {
@@ -55,7 +55,7 @@ function BamBrowser() {
   function chrSelectBuilder() {
     const refNameList = [];
 
-    ListOfSimpleReferenceNames.forEach((refName) => {
+    ListOfReferenceNames.forEach((refName) => {
       refNameList.push(
         <option
           key={refName}

--- a/src/views/ReadsSearch.js
+++ b/src/views/ReadsSearch.js
@@ -5,7 +5,7 @@ import {
 
 import { useSelector } from 'react-redux';
 
-import { ListOfSimpleReferenceNames } from '../constants/constants';
+import { ListOfReferenceNames } from '../constants/constants';
 import ReadsTable from '../components/Tables/ReadsTable';
 import {
   searchReadGroupSets, searchReads, getReferenceSet,
@@ -68,7 +68,7 @@ function ReadsSearch() {
   function chrSelectBuilder() {
     const refNameList = [];
 
-    ListOfSimpleReferenceNames.forEach((refName) => {
+    ListOfReferenceNames.forEach((refName) => {
       refNameList.push(
         <option
           key={refName}


### PR DESCRIPTION
This pull request changes the chromosome dropdown used in BamBrowser from `ListOfSimpleReferenceNames` to `ListOfReferenceNames`, this is because, apparently some BAM files use `1`, some use `chr1` when I was testing the files; it does look like that most of our own POG files use `chr_`, so perhaps we can just keep the `chr_` ones in future

I have also renamed `ListOfSimpleReferenceNames` to `ListOfShortReferenceNames`, and added a new variable named `ListOfLongReferenceNames` for future use

`ListOfSimpleReferenceNames`: `1, 2, ..., X, Y, MT`
`ListOfLongReferenceNames`: `ch1, chr2, ..., chrMT`.
`ListOfReferenceNames`: `1, 2, ..., X, Y, MT, ch1, chr2, ..., chrMT`.