### PR TITLE
fix loading indicator

### DIFF
--- a/src/components/LoadingIndicator/LoadingIndicator.js
+++ b/src/components/LoadingIndicator/LoadingIndicator.js
@@ -1,35 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Loader from 'react-loader-spinner';
 import { trackPromise, usePromiseTracker } from 'react-promise-tracker';
 
-export const LoadingIndicator = ({ area }) => {
-  const { promiseInProgress } = usePromiseTracker({ area });
-  return (
-    promiseInProgress && (
-    <div
-      style={{
-        width: '100%',
-        height: '100',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
-    >
-      <Loader type="ThreeDots" color="#2BAD60" height="100" width="100" />
-    </div>
-    )
-  );
-};
+/**
+ * Loading Indicator component
+ * This component is used when loading charts.
+ */
+const LoadingIndicator = () => (
+  <div
+    style={{
+      width: '100%',
+      height: '100',
+      padding: '10px',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    }}
+  >
+    <Loader type="Oval" color="#2BAD60" height="60" width="60" />
+  </div>
+);
 
-LoadingIndicator.propTypes = {
-  area: PropTypes.string,
-};
-
-LoadingIndicator.defaultProps = {
-  area: 'area',
-};
+export { trackPromise, usePromiseTracker, LoadingIndicator };
 
 export default LoadingIndicator;
-
-export { trackPromise, usePromiseTracker };

--- a/src/components/LoadingIndicator/SearchIndicator.js
+++ b/src/components/LoadingIndicator/SearchIndicator.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Loader from 'react-loader-spinner';
+import { trackPromise, usePromiseTracker } from 'react-promise-tracker';
+
+/**
+ * SearchIndicator component
+ * This loading indicator is used in search.
+ */
+export const SearchIndicator = ({ area }) => {
+  const { promiseInProgress } = usePromiseTracker({ area });
+  return (
+    promiseInProgress && (
+    <div
+      style={{
+        width: '100%',
+        height: '100',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Loader type="ThreeDots" color="#2BAD60" height="100" width="100" />
+    </div>
+    )
+  );
+};
+
+SearchIndicator.propTypes = {
+  area: PropTypes.string,
+};
+
+SearchIndicator.defaultProps = {
+  area: 'area',
+};
+
+export default SearchIndicator;
+
+export { trackPromise, usePromiseTracker };

--- a/src/views/BeaconSearch.js
+++ b/src/views/BeaconSearch.js
@@ -9,7 +9,7 @@ import {
 import BeaconTable from '../components/Tables/BeaconTable';
 
 import { notify, NotificationAlert } from '../utils/alert';
-import { LoadingIndicator, trackPromise } from '../components/LoadingIndicator/LoadingIndicator';
+import { SearchIndicator, trackPromise } from '../components/LoadingIndicator/SearchIndicator';
 
 // Consts
 import { BeaconFreqTableColumnDefs, BeaconRangeTableColumnDefs, ListOfReferenceNames } from '../constants/constants';
@@ -304,7 +304,7 @@ function BeaconSearch() {
           </div>
         </Row>
 
-        {displayBeaconTable ? <BeaconTable columnDefs={activeColumnDefs} rowData={rowData} datasetId={datasetId} /> : (<LoadingIndicator area="table" />) }
+        {displayBeaconTable ? <BeaconTable columnDefs={activeColumnDefs} rowData={rowData} datasetId={datasetId} /> : (<SearchIndicator area="table" />) }
 
       </div>
     </>

--- a/src/views/ReadsSearch.js
+++ b/src/views/ReadsSearch.js
@@ -13,6 +13,7 @@ import {
 
 import { notify, NotificationAlert } from '../utils/alert';
 import { LoadingIndicator, trackPromise } from '../components/LoadingIndicator/LoadingIndicator';
+import { SearchIndicator } from '../components/LoadingIndicator/SearchIndicator';
 
 import '../assets/css/VariantsSearch.css';
 
@@ -205,7 +206,7 @@ function ReadsSearch() {
           <Button>Search</Button>
         </Form>
 
-        {(displayReadsTable ? <ReadsTable rowData={rowData} datasetId={datasetId} /> : (<LoadingIndicator area="table" />))}
+        {(displayReadsTable ? <ReadsTable rowData={rowData} datasetId={datasetId} /> : (<SearchIndicator area="table" />))}
       </div>
     </>
   );

--- a/src/views/VariantsSearch.js
+++ b/src/views/VariantsSearch.js
@@ -13,6 +13,7 @@ import {
 
 import { notify, NotificationAlert } from '../utils/alert';
 import { LoadingIndicator, usePromiseTracker, trackPromise } from '../components/LoadingIndicator/LoadingIndicator';
+import { SearchIndicator } from '../components/LoadingIndicator/SearchIndicator';
 
 import '../assets/css/VariantsSearch.css';
 
@@ -187,7 +188,7 @@ function VariantsSearch() {
           <Button>Search</Button>
         </Form>
 
-        {displayVariantsTable ? <VariantsTable rowData={rowData} datasetId={datasetId} /> : (<LoadingIndicator area="table" />) }
+        {displayVariantsTable ? <VariantsTable rowData={rowData} datasetId={datasetId} /> : (<SearchIndicator area="table" />) }
       </div>
     </>
   );


### PR DESCRIPTION
The rewritten `LoadingIndicator` accidentally broke the charting loader, so I'm splitting them into two components, the previously-updated component is now its own component, named `SearchIndicator`, while the original component is kept as is.